### PR TITLE
Send logs to Grafana loki

### DIFF
--- a/.nais/default/dev-gcp.yaml
+++ b/.nais/default/dev-gcp.yaml
@@ -17,6 +17,11 @@ spec:
   prometheus:
     enabled: true
     path: /internal/metrics
+  observability:
+    logging:
+      destinations:
+        - id: elastic
+        - id: loki
   resources:
     limits:
       memory: 4096Mi

--- a/.nais/default/prod-gcp.yaml
+++ b/.nais/default/prod-gcp.yaml
@@ -17,6 +17,11 @@ spec:
   prometheus:
     enabled: true
     path: /internal/metrics
+  observability:
+    logging:
+      destinations:
+        - id: elastic
+        - id: loki
   resources:
     limits:
       memory: 4096Mi


### PR DESCRIPTION
Adds Grafana Loki as destination for logs - leads to the option on including log and log statistics on grafana dashboard