### PR TITLE
snappy-java 1.1.10.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -75,10 +75,7 @@ dependencies {
     implementation "io.prometheus:simpleclient_common:0.8.1"
     implementation "io.prometheus:simpleclient_hotspot:0.8.1"
 
-//    implementation "net.minidev:json-smart:2.4.9" //Desired transient json-smart to token-validation above
-//    implementation "org.apache.commons:commons-compress:1.26.0" //transient http4k-apache
-//    implementation "org.apache.httpcomponents:httpclient:4.5.13" //Desired transient httpclient to http4k-apache
-//    implementation "org.xerial.snappy:snappy-java:1.1.10.4" //Desired transient snappy to kafka-clients above
+    implementation "org.xerial.snappy:snappy-java:1.1.10.4" //Desired transient snappy to kafka-clients above
     implementation "org.apache.avro:avro:1.11.4" //Desired transient avro to serializer above
 
     testImplementation 'org.jetbrains.kotlin:kotlin-test'


### PR DESCRIPTION
Update transient dependency snappy-java to 1.1.10.4 to avoid vulnerability